### PR TITLE
feat: add author attribution link to footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ Example: [Safe 1.4.1 deployment](https://contractscan.xyz/bundle?name=Safe+1.4.1
 ## Contributing
 
 Feel free to extend the list of supported chains or cached contracts.
+
+---
+
+Made by [Destiner](https://destiner.io).

--- a/app/app.vue
+++ b/app/app.vue
@@ -11,7 +11,16 @@
     </header>
     <!-- eslint-disable-next-line vue/no-undef-components -->
     <NuxtPage />
-    <footer />
+    <footer>
+      <a
+        class="attribution"
+        href="https://destiner.io"
+        target="_blank"
+        rel="noopener"
+      >
+        Made by Destiner
+      </a>
+    </footer>
   </div>
 </template>
 
@@ -81,7 +90,21 @@ header {
 }
 
 footer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   min-height: 32px;
+  padding: 8px 24px;
+
+  .attribution {
+    color: var(--color-text-tertiary);
+    font-size: var(--font-size-tiny);
+    text-decoration: none;
+  }
+
+  .attribution:hover {
+    color: var(--color-text-secondary);
+  }
 }
 
 @media (width >= 768px) {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -69,7 +69,9 @@ export default withNuxt(
       'vue/no-empty-component-block': 'error',
       'vue/no-multiple-objects-in-class': 'error',
       'vue/no-required-prop-with-default': 'error',
-      'vue/no-template-target-blank': 'error',
+      // allowReferrer keeps the Referer header on outbound links so referral
+      // traffic stays attributable in analytics
+      'vue/no-template-target-blank': ['error', { allowReferrer: true }],
       'vue/no-undef-components': 'error',
       'vue/no-undef-properties': 'error',
       'vue/no-unused-emit-declarations': 'error',


### PR DESCRIPTION
Fills the empty footer placeholder with a "Made by Destiner" link to [destiner.io](https://destiner.io), and adds the same attribution line to the README.

Also sets `allowReferrer` on `vue/no-template-target-blank` so the `Referer` header is preserved on outbound links — without it the rule forces `noreferrer`, which would make referral traffic invisible in analytics.