### PR TITLE
fix: point repository links at the current owner

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -2,7 +2,7 @@
   <div class="app">
     <header>
       <a
-        href="https://github.com/scope-sh/contract-scan"
+        href="https://github.com/Destiner/contract-scan"
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git://github.com/scope-sh/contract-scan.git"
+    "url": "git+https://github.com/Destiner/contract-scan.git"
   },
   "type": "module",
   "scripts": {


### PR DESCRIPTION
The header GitHub icon and the `package.json` repository URL both still pointed at `scope-sh/contract-scan`, which now only 301s to `Destiner/contract-scan`.

Also switches the repository URL from `git://` to `git+https://` — GitHub disabled the unauthenticated git protocol in 2022, so the old value no longer resolves.